### PR TITLE
Implement search and filtering for quizzes, add tags, image uploads and improve docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Database Configuration
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres_password
+POSTGRES_DB=kahoot_clone
+TEST_POSTGRES_DB=kahoot_clone_test
+TZ=UTC
+
+# Application Configuration
+CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+DB_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+TEST_DB_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${TEST_POSTGRES_DB}
+
+# Auth Service
+AUTH_JWT_SECRET_KEY=your_secure_auth_jwt_secret
+
+# S3 Storage Configuration
+S3_REGION=ru-central1
+S3_ENDPOINT_URL=https://storage.yandexcloud.net
+S3_BUCKET=your_bucket_name
+S3_ACCESS_KEY_ID=your_aws_access_key_id
+S3_SECRET_ACCESS_KEY=your_aws_secret_access_key
+MAX_IMAGE_SIZE=5242880 # 5MB
+
+# Frontend Configuration
+NODE_ENV=development
+CHOKIDAR_USEPOLLING=true

--- a/backend-python/README.md
+++ b/backend-python/README.md
@@ -1,0 +1,49 @@
+### **Auth Service Endpoints**  
+Handles user registration, authentication, tokens, and OAuth.
+
+| Method | Endpoint                     | Description                                                                 | Auth Required |
+|--------|------------------------------|-----------------------------------------------------------------------------|--------------|
+| `GET`  | `/health`               | Health check endpoint.                                                      | No           |
+| `POST` | `/register`             | Register a new user. Returns user ID.                                       | No           |
+| `POST` | `/login`                | Authenticate user. Returns **access token** and **refresh token**.          | No           |
+| `POST` | `/refresh`              | Refresh expired access token using a valid refresh token.                   | No¹          |
+| `GET`  | `/me`                   | Get current user's profile (ID, email, username).                          | Yes (JWT)    |
+| `PUT`  | `/me`                   | Update current user's profile (email, password, etc.).                     | Yes (JWT)    |
+| `POST` | `/logout`               | Invalidate refresh token (server-side revocation).                          | Yes (JWT)    |
+| `POST` | `/logout/all`           | Invalidate all refresh tokens for the user.                                 | Yes (JWT)    |
+| `GET`  | `/oauth/{provider}`     | Initiate OAuth flow (e.g., `google`, `yandex`, `vk`). Redirects to provider. | No           |
+| `GET`  | `/oauth/{provider}/callback` | OAuth callback. Exchanges code for tokens, issues app tokens.             | No           |
+
+> **Notes**:  
+> ¹ `refresh` requires a valid refresh token in the request body.  
+
+---
+
+### **Quiz Service Endpoints**  
+Handles quizzes, tags, images, and filtering. Uses JWT for auth.
+
+| Method | Endpoint                     | Description                                                                 | Auth Required | Parameters/Request Body |
+|--------|------------------------------|-----------------------------------------------------------------------------|---------------|--------------------------|
+| `GET`  | `/health`             | Health check endpoint.                                                      | No            | -                               |
+| `POST` | `/`                   | Create a new quiz. Automatically creates/links tags.                        | Yes (JWT)     | **Body:** `title`, `description`, `is_public`, `questions` (JSON), `tags` (list of strings). |
+| `GET`  | `/{quiz_id}`         | Get quiz by ID. Unauthenticated users see only public quizzes.              | Conditional²  | -                        |
+| `PUT`  | `/{quiz_id}`         | Update quiz (title, description, questions, tags). Owner only.             | Yes (JWT)     | **Body:** Same as `POST`, partial updates allowed. |
+| `DELETE`| `/{quiz_id}`         | Delete quiz. Owner only.                                                    | Yes (JWT)     | -                        |
+| `GET`  | `/`                   | List/filter quizzes. Supports pagination.                                  | Optional      | **Query Params:**<br>- `public` (bool): Only public quizzes.<br>- `mine` (bool): Only current user's quizzes.<br>- `user_id` (UUID): Public quizzes by a user.<br>- `search` (str): Text search in title/description.<br>- `tag` (list): Filter by tags (e.g., `?tag=math&tag=science`).<br>- `page` (int), `size` (int): Pagination. |
+| `POST` | `/images`            | Upload image for quiz/question/answer. Returns **S3 URL**.                  | Yes (JWT)     | **Body:** `image` (file upload). |
+| `GET`  | `/tags`                      | List tags. Supports search and pagination.                                  | No            | **Query Params:**<br>- `name` (str): Partial tag name search.<br>- `page` (int), `size` (int). |
+| `GET`  | `/tags/{tag_id}`             | Get tag details by ID.                                                      | No            | -                        |
+
+**Notes**:  
+> ² `/{quiz_id}`:  
+>   - Public quizzes: No auth required.  
+>   - Private quizzes: Requires JWT and user must be the owner.  
+
+**Filtering Logic** for `GET /`:  
+>   - **Unauthenticated users:** Only `public=true` and `search`/`tag` filters allowed.  
+>   - **Authenticated users:**  
+>     - Default: Returns public quizzes **and** the user's own quizzes.  
+>     - `public=true`: Public quizzes only.  
+>     - `mine=true`: User's quizzes (public + private).  
+>     - `user_id=UUID`: Public quizzes by another user.  
+>     - `tag=*`: AND filter (quiz must have all specified tags).

--- a/backend-python/auth_service/auth_app/main.py
+++ b/backend-python/auth_service/auth_app/main.py
@@ -2,8 +2,10 @@ import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 
+from shared.core.config import settings as shared_settings
 from shared.db.database import async_session_maker
 
 from auth_app.api.endpoints.auth import router as auth_router
@@ -36,6 +38,14 @@ app = FastAPI(
     debug=settings.DEBUG,
     lifespan=lifespan,
     root_path="/api/auth"
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=shared_settings.cors_origins_list,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"]
 )
 
 app.include_router(auth_router)

--- a/backend-python/quiz_service/quiz_app/api/dependencies/dependencies.py
+++ b/backend-python/quiz_service/quiz_app/api/dependencies/dependencies.py
@@ -3,6 +3,7 @@ from fastapi import Depends
 from shared.db.database import async_session_maker
 from shared.utils.unitofwork import UnitOfWork
 
+from quiz_app.services.image_service import S3ImageService
 from quiz_app.services.quiz_service import QuizService
 
 uow = UnitOfWork(async_session_maker)
@@ -16,3 +17,8 @@ async def get_uow() -> UnitOfWork:
 async def get_quiz_service(_uow: UnitOfWork = Depends(get_uow)) -> QuizService:
     """Dependency that provides a QuizService instance."""
     return QuizService(_uow)
+
+
+async def get_image_service() -> S3ImageService:
+    """Dependency that provides a S3ImageService instance."""
+    return S3ImageService()

--- a/backend-python/quiz_service/quiz_app/api/endpoints/__init__.py
+++ b/backend-python/quiz_service/quiz_app/api/endpoints/__init__.py
@@ -1,0 +1,3 @@
+from .health import router as health_router
+from .quiz import router as quiz_router
+from .image import router as image_router

--- a/backend-python/quiz_service/quiz_app/api/endpoints/health.py
+++ b/backend-python/quiz_service/quiz_app/api/endpoints/health.py
@@ -1,0 +1,21 @@
+from datetime import datetime, UTC
+
+from fastapi import APIRouter, status
+
+from quiz_app.core.config import settings
+
+router = APIRouter(tags=["quiz-service"])
+
+
+@router.get(
+    "/health",
+    status_code=status.HTTP_200_OK,
+    summary="Quiz Service Health Check",
+    response_description="Service status and dependencies"
+)
+async def health_check():
+    return {
+        "status": "OK",
+        "version": settings.APP_VERSION,
+        "timestamp": datetime.now(UTC).isoformat()
+    }

--- a/backend-python/quiz_service/quiz_app/api/endpoints/image.py
+++ b/backend-python/quiz_service/quiz_app/api/endpoints/image.py
@@ -1,0 +1,47 @@
+from typing import Annotated
+
+from fastapi import Depends, File, UploadFile, APIRouter, Query, status
+
+from shared.schemas.image import ImageUploadResponse
+
+from quiz_app.services.image_service import S3ImageService
+from quiz_app.api.dependencies.dependencies import get_image_service
+
+router = APIRouter(prefix="/images", tags=["images"])
+
+
+@router.post(
+    "/upload",
+    response_model=ImageUploadResponse,
+    summary="Upload an image to S3",
+    description="Upload an image to S3 and get a url of uploaded image",
+    responses={
+        201: {"description": "Image successfully uploaded", "content": {
+            "application/json": {"example": {"url": "https://storage.yandexcloud.net/tryit/uploads/uuid.png"}}
+        }},
+        400: {"description": "Invalid file type or corrupted file"},
+        413: {"description": "File size exceeds maximum allowed"},
+        500: {"description": "Internal server error during upload"}
+    }
+)
+async def upload_image(
+        file: Annotated[UploadFile, File(description="Image file to upload (JPEG, PNG, GIF supported)")],
+        image_service: S3ImageService = Depends(get_image_service)
+):
+    return image_service.upload_file(file)
+
+
+@router.delete(
+    "/",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        204: {"description": "Image successfully deleted"},
+        404: {"description": "Image not found"},
+        500: {"description": "Internal server error during deletion"}
+    }
+)
+async def delete_image(
+        img_url: Annotated[str, Query(description="Full URL of the image to delete")],
+        image_service: S3ImageService = Depends(get_image_service)
+):
+    image_service.delete_file(img_url)

--- a/backend-python/quiz_service/quiz_app/core/config.py
+++ b/backend-python/quiz_service/quiz_app/core/config.py
@@ -1,10 +1,17 @@
 from pydantic_settings import BaseSettings
 
-from dotenv import load_dotenv
-load_dotenv()
+# from dotenv import load_dotenv
+# load_dotenv()
 
 
 class Settings(BaseSettings):
+    S3_REGION: str
+    S3_ENDPOINT_URL: str
+    S3_BUCKET: str
+    AWS_ACCESS_KEY_ID: str
+    AWS_SECRET_ACCESS_KEY: str
+    MAX_IMAGE_SIZE: int
+
     APP_NAME: str = "Quiz Service API"
     APP_VERSION: str = "1.0.0"
     DEBUG: bool = False

--- a/backend-python/quiz_service/quiz_app/exceptions/exceptions.py
+++ b/backend-python/quiz_service/quiz_app/exceptions/exceptions.py
@@ -15,7 +15,39 @@ class ForbiddenError(Exception):
         super().__init__(message)
 
 
+class BadRequestError(Exception):
+    """Base exception for when a request is bad request"""
+    def __init__(self, message: str = "Bad Request"):
+        super().__init__(message)
+
+
+class ImageS3Error(Exception):
+    """Base exception for image upload related errors"""
+    pass
+
+
 class QuizNotFoundError(NotFoundError):
     """Raised when a quiz is not found"""
     def __init__(self, identifier: str | int | UUID):
         super().__init__("Quiz", identifier)
+
+
+class InvalidQuizQueryParametersError(BadRequestError):
+    """Raised when a quiz parameters are invalid"""
+    def __init__(self, message: str = "Invalid quiz query parameters"):
+        super().__init__(message)
+
+
+class InvalidImageError(ImageS3Error):
+    """Raised when invalid image file is provided"""
+    pass
+
+
+class FileTooLargeError(ImageS3Error):
+    """Raised when file exceeds size limit"""
+    pass
+
+
+class ImageNotFoundError(ImageS3Error):
+    """Raised when image to delete is not found"""
+    pass

--- a/backend-python/quiz_service/quiz_app/exceptions/handlers.py
+++ b/backend-python/quiz_service/quiz_app/exceptions/handlers.py
@@ -4,12 +4,44 @@ from fastapi import Request, FastAPI
 from fastapi.responses import JSONResponse
 from starlette import status
 
-from quiz_app.exceptions import NotFoundError, ForbiddenError
+from quiz_app.exceptions import (NotFoundError, ForbiddenError, BadRequestError, InvalidImageError, FileTooLargeError, ImageNotFoundError, ImageS3Error)
 
 logger = logging.getLogger("app")
 
 
 def register_exception_handlers(app: FastAPI):
+    @app.exception_handler(InvalidImageError)
+    async def invalid_image_exception_handler(_: Request, exc: InvalidImageError):
+        logger.warning(f"InvalidImageError: {str(exc)}")
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={"detail": str(exc)}
+        )
+
+    @app.exception_handler(FileTooLargeError)
+    async def file_too_large_exception_handler(_: Request, exc: FileTooLargeError):
+        logger.warning(f"FileTooLargeError: {str(exc)}")
+        return JSONResponse(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            content={"detail": str(exc)}
+        )
+
+    @app.exception_handler(ImageNotFoundError)
+    async def file_not_found_exception_handler(_: Request, exc: ImageNotFoundError):
+        logger.warning(f"ImageNotFoundError: {str(exc)}")
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": str(exc)}
+        )
+
+    @app.exception_handler(ImageS3Error)
+    async def image_exception_handler(_: Request, exc: ImageS3Error):
+        logger.warning(f"ImageS3Error: {str(exc)}")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"detail": str(exc)}
+        )
+
     @app.exception_handler(NotFoundError)
     async def not_found_exception_handler(_: Request, exc: NotFoundError):
         logger.warning(f"NotFoundError: {str(exc)}")
@@ -24,6 +56,14 @@ def register_exception_handlers(app: FastAPI):
         return JSONResponse(
             status_code=status.HTTP_403_FORBIDDEN,
             content={"detail": str(exc) or "Access forbidden"},
+        )
+
+    @app.exception_handler(BadRequestError)
+    async def bad_request_exception_handler(_: Request, exc: BadRequestError):
+        logger.warning(f"BadRequestError: {str(exc)}")
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={"detail": str(exc)},
         )
 
     @app.exception_handler(Exception)

--- a/backend-python/quiz_service/quiz_app/main.py
+++ b/backend-python/quiz_service/quiz_app/main.py
@@ -2,12 +2,14 @@ import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 
+from shared.core.config import settings as shared_settings
 from shared.db.database import async_session_maker
 
 from quiz_app.init_sample_data import init_sample_data
-from quiz_app.api.endpoints.quiz import router as quiz_router
+from quiz_app.api.endpoints import health_router, quiz_router, image_router
 from quiz_app.core.config import settings
 from quiz_app.core.logging import setup_logging
 from quiz_app.exceptions.handlers import register_exception_handlers
@@ -43,6 +45,16 @@ app = FastAPI(
     root_path="/api/quiz"
 )
 
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=shared_settings.cors_origins_list,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
+
+app.include_router(health_router)
 app.include_router(quiz_router)
+app.include_router(image_router)
 
 register_exception_handlers(app)

--- a/backend-python/quiz_service/quiz_app/services/image_service.py
+++ b/backend-python/quiz_service/quiz_app/services/image_service.py
@@ -1,0 +1,109 @@
+import logging
+from uuid import uuid4
+
+import boto3
+from botocore.exceptions import ClientError, BotoCoreError
+from fastapi import UploadFile
+
+from shared.schemas.image import ImageUploadResponse
+
+from quiz_app.core.config import settings
+from quiz_app.exceptions import InvalidImageError, ImageNotFoundError, FileTooLargeError, ImageS3Error
+
+logger = logging.getLogger("app")
+
+
+class S3ImageService:
+    def __init__(self):
+        self.region = settings.S3_REGION
+        self.endpoint_url = settings.S3_ENDPOINT_URL
+        self.bucket = settings.S3_BUCKET
+        self.aws_access_key_id = settings.AWS_ACCESS_KEY_ID
+        self.aws_secret_access_key = settings.AWS_SECRET_ACCESS_KEY
+        self.max_size = settings.MAX_IMAGE_SIZE
+
+        self.client = boto3.client(
+            "s3",
+            region_name=self.region,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+            endpoint_url=self.endpoint_url
+        )
+        self.bucket_url = f"{self.client.meta.endpoint_url}/{self.bucket}"
+
+    def upload_file(self, file: UploadFile, folder: str = "uploads") -> ImageUploadResponse:
+        """
+        Uploads a file to S3 storage.
+
+        Args:
+            file: FastAPI UploadFile object
+            folder: Target folder in bucket
+
+        Returns:
+            Public URL of the uploaded file in ImageUploadResponse object.
+
+        Raises:
+            InvalidImageError: 400 - For invalid file types
+            FileTooLargeError: 413 - For files > 5MB
+            ImageS3Error: 500 - For other upload failures
+        """
+        if not file.content_type.startswith("image/"):
+            raise InvalidImageError("Only image files are allowed")
+
+        if file.size > self.max_size:
+            raise FileTooLargeError(f"File size exceeds {self.max_size} bytes limit")
+
+        file_ext = file.filename.split(".")[-1]
+        key = f"{folder}/{uuid4()}.{file_ext}"
+
+        try:
+            self.client.upload_fileobj(
+                file.file,
+                self.bucket,
+                key,
+                ExtraArgs={"ACL": "public-read", "ContentType": file.content_type}
+            )
+        except (ClientError, BotoCoreError) as e:
+            logger.error(f"S3 upload error: {str(e)}")
+            raise ImageS3Error(f"S3 upload failed: {str(e)}")
+        except Exception as e:
+            logger.error(f"Unexpected upload error: {str(e)}")
+            raise ImageS3Error(f"Upload failed: {str(e)}")
+
+        logger.info(f"Uploaded {file.filename} to {key}")
+        url = self.get_file_url(key)
+        return ImageUploadResponse(url=url)
+
+    def delete_file(self, img_url: str) -> None:
+        """
+        Deletes a file from S3 storage.
+
+        Args:
+            img_url: Public URL of the file to delete
+
+        Raises:
+            ImageNotFoundError: 404 - When file doesn't exist
+            ImageS3Error: 500 - For other deletion failures
+        """
+        try:
+            key = self.get_key_from_url(img_url)
+            self.client.delete_object(Bucket=self.bucket, Key=key)
+            logger.info(f"Deleted {key} for bucket {self.bucket}")
+        except self.client.exceptions.NoSuchKey:
+            raise ImageNotFoundError("The specified image does not exist")
+        except (ClientError, BotoCoreError) as e:
+            logger.error(f"S3 deletion error: {str(e)}")
+            raise ImageS3Error(f"S3 deletion failed: {str(e)}")
+        except Exception as e:
+            logger.error(f"Unexpected deletion error: {str(e)}")
+            raise ImageS3Error(f"Deletion failed: {str(e)}")
+
+    def get_file_url(self, key: str) -> str:
+        """Generates public URL for a given S3 key"""
+        return f"{self.bucket_url}/{key}"
+
+    def get_key_from_url(self, url: str) -> str:
+        """Extracts S3 key from public URL"""
+        if not url.startswith(self.bucket_url):
+            raise ValueError("Invalid URL - does not belong to this bucket")
+        return url.replace(f"{self.bucket_url}/", "")

--- a/backend-python/quiz_service/quiz_app/services/quiz_service.py
+++ b/backend-python/quiz_service/quiz_app/services/quiz_service.py
@@ -2,11 +2,12 @@ import logging
 from uuid import UUID
 
 from shared.db.models import Quiz as DBQuiz
-from shared.repositories import QuizRepository
-from shared.schemas.quiz import QuizCreate, QuizResponse
+from shared.repositories import QuizRepository, TagRepository
+from shared.schemas.quiz import QuizCreate, QuizUpdate, QuizResponse, QuizFilterMode
+from shared.schemas.tag import TagBase
 from shared.utils.unitofwork import UnitOfWork
 
-from quiz_app.exceptions import QuizNotFoundError, ForbiddenError
+from quiz_app.exceptions import QuizNotFoundError, ForbiddenError, InvalidQuizQueryParametersError
 
 logger = logging.getLogger("app")
 
@@ -17,31 +18,27 @@ class QuizService:
 
     async def create_quiz(self, user_id: UUID, quiz_in: QuizCreate) -> QuizResponse:
         async with self.uow.transaction() as session:
-            repo = QuizRepository(session)
-            quiz_data = quiz_in.model_dump()
+            quiz_repo = QuizRepository(session)
+            tag_repo = TagRepository(session)
+
+            # Create the Quiz object (without tags yet)
+            quiz_data = quiz_in.model_dump(exclude={"tags"})
             quiz_data["owner_id"] = user_id
-            quiz_db = await repo.create(DBQuiz(**quiz_data))
+            quiz_db = await quiz_repo.create(DBQuiz(**quiz_data))
+
+            # Normalize & validate tag names via Pydantic
+            normalized_names = {TagBase.model_validate({"name": raw}).name for raw in quiz_in.tags if raw}
+
+            # Bulk get-or-create Tag records
+            tags = await tag_repo.get_or_create_bulk(list(normalized_names))
+
+            # Associate tags onto the quiz
+            quiz_db.tags = tags
+            await session.flush()
+            await session.refresh(quiz_db)
 
             logger.info(f"Created quiz {quiz_db.id} by user {user_id}")
             return QuizResponse.model_validate(quiz_db)
-
-    async def get_public_quizzes(self) -> list[QuizResponse]:
-        async with self.uow.readonly() as session:
-            repo = QuizRepository(session)
-            public_quizzes = await repo.get_public_quizzes()
-            return [QuizResponse.model_validate(q) for q in public_quizzes]
-
-    async def get_user_quizzes(self, user_id: UUID) -> list[QuizResponse]:
-        async with self.uow.readonly() as session:
-            repo = QuizRepository(session)
-            user_quizzes = await repo.get_user_quizzes(user_id)
-            return [QuizResponse.model_validate(q) for q in user_quizzes]
-
-    async def get_visible_quizzes(self, user_id: UUID) -> list[QuizResponse]:
-        async with self.uow.readonly() as session:
-            repo = QuizRepository(session)
-            visible_quizzes = await repo.get_visible_quizzes(user_id)
-            return [QuizResponse.model_validate(q) for q in visible_quizzes]
 
     async def get_quiz_by_id(self, quiz_id: UUID, user_id: UUID | None) -> QuizResponse:
         async with self.uow.readonly() as session:
@@ -52,3 +49,117 @@ class QuizService:
             if quiz.owner_id != user_id and not quiz.is_public:
                 raise ForbiddenError("You do not own this quiz.")
             return QuizResponse.model_validate(quiz)
+
+    async def update_quiz(self, quiz_id: UUID, user_id: UUID, data: QuizUpdate) -> QuizResponse:
+        async with self.uow.transaction() as session:
+            quiz_repo = QuizRepository(session)
+            tag_repo = TagRepository(session)
+
+            quiz = await quiz_repo.get(_id=quiz_id)
+            if not quiz:
+                raise QuizNotFoundError(quiz_id)
+            if quiz.owner_id != user_id:
+                raise ForbiddenError("You do not own this quiz.")
+
+            # Update scalar fields
+            update_data = data.model_dump(exclude_none=True, exclude={'tags'})
+            for field, value in update_data.items():
+                setattr(quiz, field, value)
+
+            # If tags provided, re-normalize and re-associate
+            if data.tags is not None:
+                normalized = {TagBase.model_validate({"name": raw}).name for raw in data.tags if raw}
+                tags = await tag_repo.get_or_create_bulk(list(normalized))
+                quiz.tags = tags
+
+            await session.flush()
+            await session.refresh(quiz)
+
+            logger.info(f"Updated quiz {quiz_id} by user {user_id}")
+            return QuizResponse.model_validate(quiz)
+
+    async def delete_quiz(self, quiz_id: UUID, user_id: UUID) -> None:
+        async with self.uow.transaction() as session:
+            repo = QuizRepository(session)
+            quiz = await repo.get(_id=quiz_id)
+            if not quiz:
+                raise QuizNotFoundError(quiz_id)
+            if quiz.owner_id != user_id:
+                raise ForbiddenError("You do not own this quiz.")
+            await repo.delete(quiz)
+
+    async def list_quizzes(
+            self,
+            *,
+            requester_id: UUID | None,
+            public: bool | None = None,
+            mine: bool | None = None,
+            user_id: UUID | None = None,
+            search: str | None = None,
+            tags: list[str] | None = None,
+            page: int = 1,
+            size: int = 20
+    ) -> list[QuizResponse]:
+        filter_mode = self.resolve_filter_mode(requester_id, public, mine, user_id)
+
+        if tags:
+            tags = list({TagBase.model_validate({"name": raw}).name for raw in tags if raw})
+
+        async with self.uow.readonly() as session:
+            repo = QuizRepository(session)
+            quizzes = await repo.list_quizzes(
+                mode=filter_mode,
+                requester_id=requester_id,
+                user_id=user_id,
+                search=search,
+                tags=tags,
+                page=page,
+                size=size
+            )
+            return [QuizResponse.model_validate(q) for q in quizzes]
+
+    @staticmethod
+    def resolve_filter_mode(
+            requester_id: UUID | None,
+            public: bool | None = None,
+            mine: bool | None = None,
+            user_id: UUID | None = None
+    ) -> QuizFilterMode:
+        if requester_id is None:
+            if public is False:
+                raise InvalidQuizQueryParametersError("Cannot filter `public=false` when unauthenticated")
+            if mine:
+                raise InvalidQuizQueryParametersError("Cannot filter `mine=true` when unauthenticated")
+            if user_id is not None:
+                raise InvalidQuizQueryParametersError("Cannot filter by `user_id` when unauthenticated")
+            return QuizFilterMode.ALL_PUBLIC
+
+        # mine=True
+        if mine:
+            if user_id is not None and user_id != requester_id:
+                raise InvalidQuizQueryParametersError("Cannot filter by other users with `mine=true`")
+
+            if public is None:
+                return QuizFilterMode.ALL_MINE
+            elif public is False:
+                return QuizFilterMode.MINE_PRIVATE
+            else:
+                return QuizFilterMode.MINE_PUBLIC
+
+        # mine=False
+        if mine is False:
+            if public is False:
+                raise InvalidQuizQueryParametersError("Cannot request private quizzes of other users")
+            if user_id == requester_id:
+                raise InvalidQuizQueryParametersError("`mine=false` is incompatible with own `user_id`")
+            return QuizFilterMode.OTHER_PUBLIC
+
+        # Default visibility: mine + public
+        if public is None:
+            return QuizFilterMode.VISIBLE_TO_ME
+        elif public is False:
+            if user_id is not None and user_id != requester_id:
+                raise InvalidQuizQueryParametersError("Cannot request private quizzes of other users")
+            return QuizFilterMode.MINE_PRIVATE
+        else:
+            return QuizFilterMode.ALL_PUBLIC

--- a/backend-python/quiz_service/requirements.txt
+++ b/backend-python/quiz_service/requirements.txt
@@ -3,6 +3,8 @@ alembic==1.14.0
 annotated-types==0.7.0
 anyio==4.6.0
 asyncpg==0.30.0
+boto3==1.38.41
+botocore==1.38.41
 certifi==2024.12.14
 charset-normalizer==3.4.1
 click==8.1.7
@@ -19,6 +21,7 @@ httptools==0.6.4
 httpx==0.27.2
 idna==3.10
 iniconfig==2.0.0
+jmespath==1.0.1
 Mako==1.3.8
 MarkupSafe==3.0.2
 packaging==24.2
@@ -31,10 +34,13 @@ PyJWT==2.10.1
 pytest==8.3.4
 pytest-asyncio==1.0.0
 pytest-cov==6.1.1
+python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 python-multipart==0.0.12
 PyYAML==6.0.2
 requests==2.32.3
+s3transfer==0.13.0
+six==1.17.0
 sniffio==1.3.1
 SQLAlchemy==2.0.37
 starlette==0.38.6

--- a/backend-python/quiz_service/tests/conftest.py
+++ b/backend-python/quiz_service/tests/conftest.py
@@ -1,7 +1,9 @@
+import io
 import os
 
 import pytest
 from httpx import AsyncClient, ASGITransport
+from PIL import Image
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 
 from shared.db.models import Base, Quiz, User
@@ -95,3 +97,14 @@ async def test_quiz(uow_test, test_user):
         )
         quiz_db = await repo.create(quiz)
         return quiz_db
+
+def create_test_image():
+    image = Image.new("RGB", (100, 100), color="red")
+    img_byte_arr = io.BytesIO()
+    image.save(img_byte_arr, format="PNG")
+    img_byte_arr.seek(0)
+    return img_byte_arr
+
+@pytest.fixture
+def test_image():
+    return create_test_image()

--- a/backend-python/quiz_service/tests/test_endpoints.py
+++ b/backend-python/quiz_service/tests/test_endpoints.py
@@ -1,6 +1,27 @@
 from uuid import UUID
 
 import pytest
+from fastapi import status
+
+
+async def create_payload(tags=None):
+    return {
+        "title": "Desserts Quiz",
+        "description": "Identify all these sweet treats",
+        "is_public": False,
+        "tags": tags or ["cakes", "cookies"],
+        "questions": [
+            {
+                "type": "single_choice",
+                "text": "Which is a French dessert?",
+                "options": [
+                    {"text": "Tiramisu", "is_correct": False},
+                    {"text": "Crème brûlée", "is_correct": True},
+                    {"text": "Brownie", "is_correct": False},
+                ],
+            }
+        ]
+    }
 
 
 @pytest.mark.asyncio
@@ -35,3 +56,154 @@ async def test_get_quiz_by_id_as_unauthenticated(test_client, test_quiz):
     assert data["is_public"] is True
     assert "questions" in data
     assert len(data["questions"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_create_quiz(test_client, test_user):
+    payload = await create_payload(tags=["Sweet", "Bake_Team"])
+
+    r = await test_client.post("/", params={"user_id": test_user.id}, json=payload)
+
+    assert r.status_code == 201
+    data = r.json()
+
+    assert data["title"] == payload["title"]
+    assert data["is_public"] is False
+
+    assert isinstance(data["tags"], list)
+    returned_names = {t["name"] for t in data["tags"]}
+    assert returned_names == {"sweet", "bake_team"}
+
+
+QUIZ_EXAMPLE = {
+    "title": "Advanced Python",
+    "description": "A quiz about advanced Python topics.",
+    "is_public": True,
+    "questions": [
+        {
+            "type": "single_choice",
+            "text": "What is the output of print(type(lambda x: x))?",
+            "options": [
+                {"text": "<class 'function'>", "is_correct": True},
+                {"text": "<class 'lambda'>", "is_correct": False},
+                {"text": "<class 'method'>", "is_correct": False},
+                {"text": "<lambda>", "is_correct": False}
+            ]
+        }
+    ]
+}
+
+
+@pytest.mark.asyncio
+async def test_create_quiz(test_client, test_user):
+    response = await test_client.post(
+        "/",
+        json=QUIZ_EXAMPLE,
+        params={"user_id": str(test_user.id)}
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.json()
+    assert data["title"] == QUIZ_EXAMPLE["title"]
+    assert len(data["questions"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_quiz_by_id(test_client, test_user, test_quiz):
+    response = await test_client.get(
+        f"/{test_quiz.id}",
+        params={"user_id": str(test_user.id)}
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["id"] == str(test_quiz.id)
+    assert data["title"] == test_quiz.title
+
+
+@pytest.mark.asyncio
+async def test_update_quiz(test_client, test_user, test_quiz):
+    updated_data = {
+        "title": "Updated Title",
+        "description": "Updated Description",
+        "is_public": False
+    }
+    response = await test_client.put(
+        f"/{test_quiz.id}",
+        json=updated_data,
+        params={"user_id": str(test_user.id)}
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["title"] == "Updated Title"
+    assert data["is_public"] is False
+
+
+@pytest.mark.asyncio
+async def test_delete_quiz(test_client, test_user, test_quiz):
+    response = await test_client.delete(
+        f"/{test_quiz.id}",
+        params={"user_id": str(test_user.id)}
+    )
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    # Ensure it no longer exists
+    get_response = await test_client.get(f"/{test_quiz.id}", params={"user_id": str(test_user.id)})
+    assert get_response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_list_quizzes_all_public(test_client, test_user, test_quiz):
+    response = await test_client.get("/")
+    assert response.status_code == status.HTTP_200_OK
+    quizzes = response.json()
+    assert isinstance(quizzes, list)
+    assert any(q["id"] == str(test_quiz.id) for q in quizzes)
+
+
+@pytest.mark.asyncio
+async def test_list_quizzes_mine(test_client, test_user, test_quiz):
+    response = await test_client.get("/", params={"mine": "true", "user_id_req": str(test_user.id)})
+    assert response.status_code == status.HTTP_200_OK
+    quizzes = response.json()
+    assert all(q["id"] == str(test_quiz.id) for q in quizzes)
+
+
+@pytest.mark.asyncio
+async def test_list_quizzes_filter_by_user_unauthorized(test_client, test_user, test_quiz):
+    response = await test_client.get("/", params={"user_id": str(test_user.id), "public": "true"})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_list_quizzes_filter_by_user_authorized(test_client, test_user, test_quiz):
+    response = await test_client.get("/", params={"user_id": str(test_user.id), "public": "true", "user_id_req": str(test_user.id)})
+    assert response.status_code == status.HTTP_200_OK
+    quizzes = response.json()
+    assert any(q["id"] == str(test_quiz.id) for q in quizzes)
+
+
+@pytest.mark.asyncio
+async def test_list_quizzes_unauthenticated_forbidden_private(test_client):
+    response = await test_client.get("/", params={"public": "false"})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_list_quizzes_search(test_client, test_user, test_quiz):
+    response = await test_client.get("/", params={"search": "Python"})
+    assert response.status_code == status.HTTP_200_OK
+    quizzes = response.json()
+    assert any("Python" in q["title"] for q in quizzes)
+
+@pytest.mark.asyncio
+async def test_upload_and_delete_image_success(test_client, test_image):
+    files = {"file": ("test.png", test_image, "image/png")}
+    response = await test_client.post("/images/upload", files=files)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert "url" in response.json()
+    assert response.json()["url"].startswith("https://")
+
+    img_url = response.json()["url"]
+
+    response = await test_client.delete(f"/images/?img_url={img_url}")
+    assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/backend-python/shared/shared/core/config.py
+++ b/backend-python/shared/shared/core/config.py
@@ -1,11 +1,16 @@
 from pydantic_settings import BaseSettings
 
-from dotenv import load_dotenv
-load_dotenv()
+# from dotenv import load_dotenv
+# load_dotenv()
 
 
 class Settings(BaseSettings):
     DB_URL: str
+    CORS_ORIGINS: str
+
+    @property
+    def cors_origins_list(self) -> list[str]:
+        return [origin.strip() for origin in self.CORS_ORIGINS.split(",") if origin.strip()]
 
 
 settings = Settings()

--- a/backend-python/shared/shared/db/models.py
+++ b/backend-python/shared/shared/db/models.py
@@ -63,7 +63,8 @@ class Quiz(Base):
     tags: Mapped[List["Tag"]] = relationship(
         secondary="quiz_tags",
         back_populates="quizzes",
-        passive_deletes=True
+        passive_deletes=True,
+        lazy="selectin"
     )
 
 

--- a/backend-python/shared/shared/repositories/__init__.py
+++ b/backend-python/shared/shared/repositories/__init__.py
@@ -1,2 +1,3 @@
 from .user_repo import UserRepository
 from .quiz_repo import QuizRepository
+from .tag_repo import TagRepository

--- a/backend-python/shared/shared/repositories/quiz_repo.py
+++ b/backend-python/shared/shared/repositories/quiz_repo.py
@@ -1,10 +1,13 @@
+import re
 from typing import Sequence
 from uuid import UUID
 
-from sqlalchemy import select, or_
+from sqlalchemy import select, or_, and_, func
+from sqlalchemy.orm import selectinload
 
-from shared.db.models import Quiz
+from shared.db.models import Quiz, QuizTag, Tag
 from shared.repositories.base_repo import BaseRepository
+from shared.schemas.quiz import QuizFilterMode
 
 
 class QuizRepository(BaseRepository[Quiz]):
@@ -12,22 +15,67 @@ class QuizRepository(BaseRepository[Quiz]):
     def model(self) -> type[Quiz]:
         return Quiz
 
-    async def get_public_quizzes(self) -> Sequence[Quiz]:
-        stmt = select(Quiz).where(Quiz.is_public.is_(True))
-        result = await self._session.execute(stmt)
-        return result.scalars().all()
+    async def list_quizzes(
+            self,
+            *,
+            mode: QuizFilterMode,
+            requester_id: UUID | None = None,
+            user_id: UUID | None = None,
+            search: str | None = None,
+            tags: list[str] | None = None,
+            page: int = 1,
+            size: int = 20
+    ) -> Sequence[Quiz]:
+        # Eager‐load tags
+        stmt = select(Quiz).options(selectinload(Quiz.tags))
 
-    async def get_user_quizzes(self, user_id: UUID) -> Sequence[Quiz]:
-        stmt = select(Quiz).where(Quiz.owner_id == user_id)
-        result = await self._session.execute(stmt)
-        return result.scalars().all()
+        # Handle filtering modes
+        if mode == QuizFilterMode.ALL_PUBLIC:
+            stmt = stmt.where(Quiz.is_public.is_(True))
+        elif mode == QuizFilterMode.ALL_MINE:
+            stmt = stmt.where(Quiz.owner_id == requester_id)
+        elif mode == QuizFilterMode.MINE_PUBLIC:
+            stmt = stmt.where(and_(Quiz.owner_id == requester_id, Quiz.is_public.is_(True)))
+        elif mode == QuizFilterMode.MINE_PRIVATE:
+            stmt = stmt.where(and_(Quiz.owner_id == requester_id, Quiz.is_public.is_(False)))
+        elif mode == QuizFilterMode.OTHER_PUBLIC:
+            stmt = stmt.where(and_(Quiz.owner_id == user_id, Quiz.is_public.is_(True)))
+        elif mode == QuizFilterMode.VISIBLE_TO_ME:
+            stmt = stmt.where(or_(Quiz.owner_id == requester_id, Quiz.is_public.is_(True)))
 
-    async def get_visible_quizzes(self, user_id: UUID) -> Sequence[Quiz]:
-        stmt = select(Quiz).where(
-            or_(
-                Quiz.is_public.is_(True),
-                Quiz.owner_id == user_id
+        # Apply user_id filtering
+        if user_id is not None:
+            stmt = stmt.where(Quiz.owner_id == user_id)
+
+        # Apply search
+        if search:
+            cleaned_search = re.sub(r"[^\w\s]", "", search).strip()
+            if cleaned_search:
+                tsvector = func.to_tsvector("english", Quiz.title + " " + Quiz.description)
+
+                query_terms = " & ".join(cleaned_search.split())
+                tsquery = func.to_tsquery("english", query_terms)
+
+                stmt = stmt.where(tsvector.op("@@")(tsquery))
+                stmt = stmt.order_by(
+                    func.ts_rank(tsvector, tsquery).desc(),
+                    Quiz.created_at.desc()
+                )
+
+        # Apply tags filtering
+        if tags:
+            stmt = (
+                stmt
+                .join(QuizTag, QuizTag.quiz_id == Quiz.id)
+                .join(Tag, Tag.id == QuizTag.tag_id)
+                .where(Tag.name.in_(tags))
+                .group_by(Quiz.id)
+                .having(func.count(Tag.id) == len(set(tags)))
             )
-        )
-        result = await self._session.execute(stmt)
-        return result.scalars().all()
+
+        # Apply paging
+        offset = (page - 1) * size
+        stmt = stmt.limit(size).offset(offset)
+
+        res = await self._session.execute(stmt)
+        return res.scalars().all()

--- a/backend-python/shared/shared/repositories/tag_repo.py
+++ b/backend-python/shared/shared/repositories/tag_repo.py
@@ -1,0 +1,42 @@
+from typing import List, Sequence
+from uuid import UUID
+
+from sqlalchemy import select
+
+from shared.db.models import Tag, QuizTag
+from shared.repositories.base_repo import BaseRepository
+
+
+class TagRepository(BaseRepository[Tag]):
+    @property
+    def model(self) -> type[Tag]:
+        return Tag
+
+    async def get_by_name(self, name: str) -> Tag | None:
+        stmt = select(Tag).where(Tag.name == name)
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_or_create_bulk(self, tag_names: List[str]) -> List[Tag]:
+        """
+        Given a list of normalized tag names, returns Tag objects,
+        creating any that don’t already exist.
+        """
+        stmt = select(Tag).where(Tag.name.in_(tag_names))
+        result = await self._session.execute(stmt)
+        existing_tags = {t.name: t for t in result.scalars().all()}
+
+        tags_result: List[Tag] = []
+        for name in tag_names:
+            if name in existing_tags:
+                tags_result.append(existing_tags[name])
+            else:
+                tag = Tag(name=name)
+                await self.create(tag)
+                tags_result.append(tag)
+        return tags_result
+
+    async def get_tags_for_quiz(self, quiz_id: UUID) -> Sequence[Tag]:
+        stmt = select(Tag).join(QuizTag).where(QuizTag.quiz_id == quiz_id)
+        result = await self._session.execute(stmt)
+        return result.scalars().all()

--- a/backend-python/shared/shared/schemas/image.py
+++ b/backend-python/shared/shared/schemas/image.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class ImageUploadResponse(BaseModel):
+    url: str

--- a/backend-python/shared/shared/schemas/quiz.py
+++ b/backend-python/shared/shared/schemas/quiz.py
@@ -3,6 +3,8 @@ from enum import Enum
 from typing import Annotated, List, Literal, Optional, Union
 from uuid import UUID
 
+from shared.schemas.tag import TagResponse
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
@@ -59,8 +61,18 @@ class QuizCreate(BaseModel):
     title: Annotated[str, Field(max_length=200)]
     description: Optional[str] = None
     is_public: bool = False
-    # tags: Annotated[List[str], Field(max_length=10)] = []
+    tags: Annotated[List[str], Field(max_length=10)] = []
     questions: Annotated[List[Question], Field(min_length=1, max_length=100)]
+
+
+class QuizUpdate(BaseModel):
+    model_config = ConfigDict(strict=True)
+
+    title: Optional[Annotated[str, Field(max_length=200)]] = None
+    description: Optional[str] = None
+    is_public: Optional[bool] = None
+    tags: Optional[Annotated[List[str], Field(max_length=10)]] = None
+    questions: Optional[Annotated[List[Question], Field(min_length=1, max_length=100)]] = None
 
 
 class QuizResponse(QuizCreate):
@@ -68,5 +80,16 @@ class QuizResponse(QuizCreate):
     owner_id: UUID
     created_at: datetime
     updated_at: datetime
+    tags: List[TagResponse]
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class QuizFilterMode(str, Enum):
+    """Defines the base visibility filter for quizzes."""
+    ALL_PUBLIC = "all_public"
+    ALL_MINE = "all_mine"
+    MINE_PUBLIC = "mine_public"
+    MINE_PRIVATE = "mine_private"
+    OTHER_PUBLIC = "other_public"
+    VISIBLE_TO_ME = "visible_to_me"

--- a/backend-python/shared/shared/schemas/tag.py
+++ b/backend-python/shared/shared/schemas/tag.py
@@ -1,0 +1,32 @@
+import re
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+TAG_NAME_REGEX = re.compile(r"^[a-z0-9_-]{1,50}$")
+
+
+class TagBase(BaseModel):
+    model_config = ConfigDict(strict=True)
+
+    name: Annotated[
+        str,
+        Field(
+            max_length=50,
+            description="Lowercase letters, numbers, hyphens or underscores only"
+        )
+    ]
+
+    @field_validator("name")
+    @classmethod
+    def validate_and_normalize(cls, v: str) -> str:
+        normalized = v.strip().lower()
+        if not TAG_NAME_REGEX.match(normalized):
+            raise ValidationError("Tag must be 1–50 chars of [a–z0–9_-] only")
+        return normalized
+
+
+class TagResponse(TagBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,14 +5,14 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres_password
-      POSTGRES_DB: kahoot_clone
-      TZ: UTC
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      TZ: ${TZ}
     ports:
       - "5432:5432"
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres -d kahoot_clone" ]
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -23,8 +23,8 @@ services:
       context: backend-python/shared
       dockerfile: Dockerfile
     environment:
-      PYTHONPATH: ./shared
-      DB_URL: postgresql+asyncpg://postgres:postgres_password@postgres:5432/kahoot_clone
+      CORS_ORIGINS: ${CORS_ORIGINS}
+      DB_URL: ${DB_URL}
     depends_on:
       postgres:
         condition: service_healthy
@@ -36,12 +36,11 @@ services:
     ports:
       - "8000:8000"
     environment:
-      SECRET_KEY: M7oif5ZAON9wGNDRw9X8-Q
-      PYTHONPATH: ./app
-      DB_URL: postgresql+asyncpg://postgres:postgres_password@postgres:5432/kahoot_clone
+      CORS_ORIGINS: ${CORS_ORIGINS}
+      SECRET_KEY: ${AUTH_JWT_SECRET_KEY}
+      DB_URL: ${DB_URL}
     depends_on:
-      postgres:
-        condition: service_healthy
+      - migrator
 
   quiz:
     build:
@@ -50,8 +49,15 @@ services:
     ports:
       - "8001:8000"
     environment:
-      PYTHONPATH: ./app
-      DB_URL: postgresql+asyncpg://postgres:postgres_password@postgres:5432/kahoot_clone
+      CORS_ORIGINS: ${CORS_ORIGINS}
+      S3_REGION: ${S3_REGION}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL}
+      S3_BUCKET: ${S3_BUCKET}
+      AWS_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
+      MAX_IMAGE_SIZE: ${MAX_IMAGE_SIZE}
+      DB_URL: ${DB_URL}
+      TEST_DB_URL: ${TEST_DB_URL}
     depends_on:
       - auth
 
@@ -65,8 +71,8 @@ services:
       - ./frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - /app/node_modules
     environment:
-      - NODE_ENV=development
-      - CHOKIDAR_USEPOLLING=true
+      - NODE_ENV=${NODE_ENV}
+      - CHOKIDAR_USEPOLLING=${CHOKIDAR_USEPOLLING}
     depends_on:
       - quiz
 


### PR DESCRIPTION
Implemented the following functionality:
- add full CRUD support for quizzes
- add tags support for quizzes
- add searching and filtering support for quizzes
- add integration tests for all quizzes related endpoints and edge cases
- add S3 images uploading support and integration tests
- add simple README.md for all endpoints and services (Swagger available too)
- edit docker compose to use env vars instead of raw secrets
- add .env.example