### PR TITLE
add /healthz endpoint

### DIFF
--- a/backend-go/SessionService/Game/Game.go
+++ b/backend-go/SessionService/Game/Game.go
@@ -24,6 +24,7 @@ type Manager interface {
 	AddPlayerToSession(quizUUID string, UserName string) error
 	SessionStartMock(quizUUID string, sessionId string) error
 	SessionEnd(code string) error
+	CheckService() error
 }
 
 type SessionManager struct {
@@ -201,6 +202,18 @@ func (manager *SessionManager) SessionEnd(code string) error {
 	err := manager.rabbit.PublishSessionEnd(context.Background(), code, "aboba")
 	if err != nil {
 		return fmt.Errorf("error to send message to rabbit %s", err)
+	}
+	return nil
+}
+
+func (manager *SessionManager) CheckService() error {
+	err := manager.cache.CheckRedisAlive()
+	if err != nil {
+		return fmt.Errorf("redis error %v", err)
+	}
+	err = manager.rabbit.CheckRabbitAlive()
+	if err != nil {
+		return fmt.Errorf("rabbit error %v", err)
 	}
 	return nil
 }

--- a/backend-go/SessionService/Handlers/HealthzHandler.go
+++ b/backend-go/SessionService/Handlers/HealthzHandler.go
@@ -1,0 +1,28 @@
+package Handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"xxx/SessionService/models"
+)
+
+func (h *SessionManagerHandler) HealthHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.logger.Info("CreateSessionHandler request method not allowed ", "Request Method", r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		json.NewEncoder(w).Encode(models.ErrorResponse{Message: "Only GET method is allowed"})
+		return
+	}
+	err := h.Manager.CheckService()
+	if err != nil {
+		h.logger.Error("HealthHandler err",
+			"err", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(models.ErrorResponse{Message: "Internal Server Error"})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+}

--- a/backend-go/SessionService/Rabbit/CheckRabbitAlive.go
+++ b/backend-go/SessionService/Rabbit/CheckRabbitAlive.go
@@ -1,0 +1,25 @@
+package Rabbit
+
+import (
+	"fmt"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"os"
+)
+
+func (r *Rabbit) CheckRabbitAlive() error {
+	rabbitUrl := fmt.Sprintf("amqp://%s:%s@%s:%s/",
+		os.Getenv("RABBITMQ_USER"), os.Getenv("RABBITMQ_PASSWORD"),
+		os.Getenv("RABBITMQ_HOST"), os.Getenv("RABBITMQ_PORT"))
+	conn, err := amqp.Dial(rabbitUrl)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		return err
+	}
+	defer ch.Close()
+	return nil
+}

--- a/backend-go/SessionService/Rabbit/Rabbit.go
+++ b/backend-go/SessionService/Rabbit/Rabbit.go
@@ -15,6 +15,7 @@ type Broker interface {
 	PublishQuestionStart(ctx context.Context, SessionCode string, payload interface{}) error
 	PublishSessionEnd(ctx context.Context, SessionCode string, payload interface{}) error
 	PublishSessionStart(ctx context.Context, payload interface{}) error
+	CheckRabbitAlive() error
 }
 
 func NewRabbit(rmq_host string) (*Rabbit, error) {

--- a/backend-go/SessionService/Storage/Redis/redis.go
+++ b/backend-go/SessionService/Storage/Redis/redis.go
@@ -17,6 +17,7 @@ type Cache interface {
 	CodeExist(code string) bool
 	GetPlayersForSession(sessionCode string) ([]string, error)
 	AddPlayerToSession(sessionCode string, playerName string) error
+	CheckRedisAlive() error
 }
 
 type Redis struct {
@@ -134,4 +135,12 @@ func (r *Redis) GetPlayersForSession(sessionCode string) ([]string, error) {
 	}
 
 	return players, nil
+}
+
+func (r *Redis) CheckRedisAlive() error {
+	_, err := r.Client.Ping(context.Background()).Result()
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/backend-go/SessionService/httpServer/httpServer.go
+++ b/backend-go/SessionService/httpServer/httpServer.go
@@ -85,7 +85,7 @@ func (hs *HttpServer) registerHandlers() *mux.Router {
 	router.HandleFunc("/validate", hs.ValidateSessionCodeHandler).Methods("POST")
 	router.HandleFunc("/sessionsMock", hs.CreateSessionHandlerMock).Methods("POST")
 	router.HandleFunc("/session/{id}/end", hs.SessionEndHandler).Methods("POST")
-
+	router.HandleFunc("/healthz", hs.HealthHandler).Methods("POST")
 	registry := Handlers.NewConnectionRegistry(hs.logger)
 	router.Handle("/ws", Handlers.NewWebSocketHandler(registry))
 

--- a/backend-go/SessionService/integration_tests/HttpServerHealth_test.go
+++ b/backend-go/SessionService/integration_tests/HttpServerHealth_test.go
@@ -1,0 +1,59 @@
+package integration_tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/joho/godotenv"
+	"golang.org/x/net/context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+	"xxx/SessionService/httpServer"
+	"xxx/SessionService/models"
+)
+
+func Test_HttpServerHealth(t *testing.T) {
+	if os.Getenv("ENV") != "production" && os.Getenv("ENV") != "test" {
+		if err := godotenv.Load(getEnvFilePath()); err != nil {
+			t.Fatalf("could not load .env file: %v", err)
+		}
+	}
+
+	host := os.Getenv("SESSION_SERVICE_HOST")
+	port := os.Getenv("SESSION_SERVICE_PORT")
+	rabbitC, rabbitURL := startRabbit(context.Background(), t)
+	redisC, redisURL := startRedis(context.Background(), t)
+	defer redisC.Terminate(context.Background())
+	defer rabbitC.Terminate(context.Background())
+	// Запуск канала RabbitMQ для question.{sessionID}.start
+	// ⚙️ Создаем логгер и запускаем сервер
+	log := setupLogger(envLocal)
+	server, err := httpServer.InitHttpServer(log, host, port, rabbitURL, redisURL)
+	if err != nil {
+		t.Fatalf("error creating http server: %v", err)
+	}
+	go server.Start()
+	time.Sleep(1 * time.Second)
+	defer server.Stop()
+	// 🛠️ Создаем сессию
+	SessionServiceUrl := fmt.Sprintf("http://%s:%s/healthz", host, port)
+	req := models.CreateSessionReq{
+		UserId: "1",
+		QuizId: "d2372184-dedf-42db-bcbd-d6bb15b0712b",
+	}
+	jsonBytes, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal("error marshaling json:", err)
+	}
+	resp, err := http.Post(SessionServiceUrl, "application/json", bytes.NewReader(jsonBytes))
+	if err != nil {
+		t.Fatal("error making request:", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code: got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## ✅ Feature: /healthz endpoint to check service health

### Added
- New HTTP endpoint `GET /healthz` to perform a health check of core infrastructure services.
- Internally checks the availability of:
  - **Redis** via `PING` command
  - **RabbitMQ** via connection and channel creation

### Behavior
- Returns **200 OK** if both Redis and RabbitMQ are reachable and functioning.
- Returns **500 Internal Server Error** if any of the services are unavailable.